### PR TITLE
Follow screenOrientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,8 +40,7 @@
             android:theme="@style/AppTheme">
         <activity
                 android:name=".MainActivity"
-                android:label="@string/app_name"
-                android:screenOrientation="nosensor">
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/bobek/compass/view/CompassView.kt
+++ b/app/src/main/java/com/bobek/compass/view/CompassView.kt
@@ -20,6 +20,7 @@ package com.bobek.compass.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.WindowManager
 import androidx.annotation.IdRes
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
@@ -63,7 +64,9 @@ class CompassView(context: Context, attributeSet: AttributeSet) : ConstraintLayo
         updateStatusDegreesText()
         updateStatusDirectionText()
 
-        val rotation = azimuth.degrees.unaryMinus()
+        val display = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val orientationOffset = (display.defaultDisplay.rotation) * 90
+        val rotation = azimuth.degrees.unaryMinus() - orientationOffset
         rotateCompassRoseImage(rotation)
         rotateCompassRoseTexts(rotation)
     }


### PR DESCRIPTION
Apps that don't allow me to re-orient them are one of my pet-peeves and forcing
apps to follow screenOrientation anyways through an overlay works in 95/100
cases.

Here, it wasn't as trivial though because changing the orientation rotates the
app and therefore the compass. Landscape, inverse portrait and inverse landscape
need it to be rotated by -90, -180 and -270 degrees respectively to compensate
for this effect.

The implementation is not pretty but it's the best API for that kind of thing I
could find.

Btw, gradle wouldn't let me sync initially because `distributionSha256Sum` being set in the wrapper props; you might want to look into that.