### PR TITLE
Use best fitting LocationProvider

### DIFF
--- a/app/src/main/java/com/bobek/compass/model/AppError.kt
+++ b/app/src/main/java/com/bobek/compass/model/AppError.kt
@@ -25,5 +25,6 @@ enum class AppError(@StringRes val messageId: Int) {
     SENSOR_MANAGER_NOT_PRESENT(R.string.sensor_error_message),
     ROTATION_VECTOR_SENSOR_NOT_AVAILABLE(R.string.sensor_error_message),
     ROTATION_VECTOR_SENSOR_FAILED(R.string.sensor_error_message),
-    LOCATION_MANAGER_NOT_PRESENT(R.string.location_error_message)
+    LOCATION_MANAGER_NOT_PRESENT(R.string.location_error_message),
+    NO_LOCATION_PROVIDER_AVAILABLE(R.string.location_error_message)
 }


### PR DESCRIPTION
Use best fitting LocationProvider instead of the hard coded Network provider.
Fixes crash when the hard coded Network provider is not present.