### PR TITLE
Fix source strings typos

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,14 +46,14 @@
     <string name="sensor_accuracy_low">Low accuracy</string>
     <string name="sensor_accuracy_medium">Average accuracy</string>
     <string name="sensor_accuracy_high">Maximum accuracy</string>
-    <string name="sensor_accuracy_image_description">Indicates graphically the sensors accuracy</string>
+    <string name="sensor_accuracy_image_description">Indicates graphically the sensor\'s accuracy</string>
     <string name="sensor_error_message">Sensor not available</string>
     <string name="sensor_calibration_text">You can try to improve your sensor accuracy at any time by rotating the device in a figure 8 pattern.</string>
 
     <string name="location_loading">Waiting for location update</string>
     <string name="location_error_message">Location not available</string>
-    <string name="access_coarse_location_permission_rationale_title">We need permission to access your course location</string>
-    <string name="access_coarse_location_permission_rationale_message">For showing to true north this app needs to determine the magnetic declination based on your current location.</string>
+    <string name="access_coarse_location_permission_rationale_title">We need permission to access your coarse location</string>
+    <string name="access_coarse_location_permission_rationale_message">For showing to true north, this app needs to determine the magnetic declination based on your current location.</string>
     <string name="access_coarse_location_permission_denied">Missing permission to access coarse location. Falling back to magnetic north.</string>
 
     <string name="settings">Settings</string>
@@ -82,7 +82,7 @@
     <string name="ok">OK</string>
     <string name="no_thanks">No thanks</string>
 
-    <string name="source_code_name" translatable="false">Git Hub</string>
+    <string name="source_code_name" translatable="false">GitHub</string>
     <string name="license_name" translatable="false">GNU GPLv3</string>
     <string name="author_name" translatable="false">Philipp Bobek</string>
 


### PR DESCRIPTION
While I was translating I had noticed some typos in the English source strings, so I went back to correct them